### PR TITLE
Add deployment repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: Deployment
+
+on:
+  push:
+    branches: [master]
+
+env:
+  node_version: "14"
+
+jobs:
+  publish:
+    name: Publish npm package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+
+      - name: Disallow Concurrent Runs
+        uses: byu-oit/github-action-disallow-concurrent-runs@v2
+        with:
+          token: ${{ github.token }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2.1.4
+        with:
+          node-version: ${{ env.node_version }}
+          registry-url: https://npm.pkg.github.com
+          scope: '@byu-oit'
+
+      - name: Install
+        run: npm install
+
+      - name: Test
+        run: npm run test
+
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+# TODO: Add NPM_TOKEN to repo secret and uncomment to automatically publish to NPM also.
+#      - name: Set up Node.js
+#        uses: actions/setup-node@v2.1.4
+#        with:
+#          node-version: ${{ env.node_version }}
+#          registry-url: https://registry.npmjs.org
+#          scope: '@byu-oit'
+#
+#      - name: Publish
+#        run: npm publish
+#        env:
+#          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,5 +47,3 @@ jobs:
 
       - name: Publish
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,15 +38,14 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-# TODO: Add NPM_TOKEN to repo secret and uncomment to automatically publish to NPM also.
-#      - name: Set up Node.js
-#        uses: actions/setup-node@v2.1.4
-#        with:
-#          node-version: ${{ env.node_version }}
-#          registry-url: https://registry.npmjs.org
-#          scope: '@byu-oit'
-#
-#      - name: Publish
-#        run: npm publish
-#        env:
-#          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Set up Node.js
+        uses: actions/setup-node@v2.1.4
+        with:
+          node-version: ${{ env.node_version }}
+          registry-url: https://registry.npmjs.org
+          scope: '@byu-oit'
+
+      - name: Publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/index.ts
+++ b/index.ts
@@ -21,11 +21,17 @@ export namespace UAPI {
       date_time: string
     }
     export type Restricted = boolean
+    export type FieldSetsReturned = string[]
+    export type FieldSetsAvailable = string[]
+    export type FieldSetsDefault = string[]
     export interface Simple {
       validation_response: ValidationResponse
       validation_information?: ValidationInformation
       cache?: Cache
       restricted?: Restricted
+      field_sets_returned?: FieldSetsReturned,
+      field_sets_available?: FieldSetsAvailable,
+      field_sets_default?: FieldSetsDefault
     }
     export type CollectionSize = number
     export interface Collection extends Simple {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byu-oit/uapi-ts",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "TypeScript definitions of UAPI elements",
   "main": "index.ts",
   "files": [


### PR DESCRIPTION
Since we're suing GitHub package manager for our payment manager packages, they must be scoped with the orgs name. Since they're scoped with @byu-oit, any @byu-oit package we want to use must be in GitHub pacakges. This will deploy these types to GPM and provide a way to do it to NPM.
