### PR TITLE
Remove NPM registry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,12 +38,12 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v2.1.4
-        with:
-          node-version: ${{ env.node_version }}
-          registry-url: https://registry.npmjs.org
-          scope: '@byu-oit'
+#       - name: Set up Node.js
+#         uses: actions/setup-node@v2.1.4
+#         with:
+#           node-version: ${{ env.node_version }}
+#           registry-url: https://registry.npmjs.org
+#           scope: '@byu-oit'
 
-      - name: Publish
-        run: npm publish --access public
+#       - name: Publish
+#         run: npm publish --access public


### PR DESCRIPTION
BYU OIT doesn't have a way to manage NPM access tokens since we don't own an NPM org (just the namespace). Paying for GitHub and NPM seems unnecessary so we'll publish just to GitHub's registry now. We should probably discuss this decision in our standards/conventions committee before this become official.