### PR TITLE
Remove enum api type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,18 +60,13 @@ export namespace UAPI {
 
   export type PropertyDictionary = Record<string, Property<any> | ComplexProperty<any>>
 
-  export enum ApiType {
-    READONLY = 'read-only',
-    MODIFIABLE = 'modifiable',
-    SYSTEM = 'system',
-    DERIVED = 'derived',
-    UNAUTHORIZED = 'unauthorized',
-    RELATED = 'related'
-  }
+  export type ApiType = 'readonly' | 'modifiable' | 'system' | 'derived' | 'unauthorized' | 'related'
+
+  export type ObjectApiType = 'readonly' | 'related'
 
   export type Value<T extends Scalar.Type> = {
     value: T | null
-    api_type: ApiType.READONLY | ApiType.MODIFIABLE | ApiType.SYSTEM | ApiType.DERIVED | ApiType.UNAUTHORIZED | ApiType.RELATED
+    api_type: ApiType
     key?: boolean
     description?: string
     long_description?: string
@@ -82,7 +77,7 @@ export namespace UAPI {
 
   export type ValueArray<T extends Scalar.Type> = {
     value_array: Value<T>[]
-    api_type: ApiType.READONLY | ApiType.MODIFIABLE | ApiType.SYSTEM | ApiType.DERIVED | ApiType.UNAUTHORIZED | ApiType.RELATED
+    api_type: ApiType
     description?: string
     long_description?: string
     display_label?: string
@@ -92,14 +87,14 @@ export namespace UAPI {
 
   export type Object<T extends PropertyDictionary> = {
     object: T | null
-    api_type: ApiType.READONLY | ApiType.RELATED
+    api_type: ObjectApiType
     display_label?: string
     related_resource?: string
   }
 
   export type ObjectArray<T extends PropertyDictionary> = {
     object_array: T[]
-    api_type: ApiType.READONLY | ApiType.RELATED
+    api_type: ObjectApiType
     display_label?: string
     related_resource?: string
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byu-oit/uapi-ts",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "TypeScript definitions of UAPI elements",
   "main": "index.d.ts",
   "files": [

--- a/test/students-v3-api.spec.ts
+++ b/test/students-v3-api.spec.ts
@@ -91,193 +91,193 @@ export namespace StudentsV3API {
                 },
                 byu_id: {
                     value: '123456789',
-                    api_type: UAPI.ApiType.READONLY,
+                    api_type: 'readonly',
                     key: true,
                     description: 'LastName, FirstName'
                 },
                 year_term: {
                     value: '20185',
-                    api_type: UAPI.ApiType.READONLY,
+                    api_type: 'readonly',
                     key: true,
                     description: 'Fall 2018',
                     long_description: 'Fall Semester 2018'
                 },
                 curriculum_id: {
                     value: '10314',
-                    api_type: UAPI.ApiType.READONLY,
+                    api_type: 'readonly',
                     key: true
                 },
                 title_code: {
                     value: '000',
-                    api_type: UAPI.ApiType.READONLY,
+                    api_type: 'readonly',
                     key: true
                 },
                 teaching_area: {
                     value: 'C S',
-                    api_type: UAPI.ApiType.READONLY,
+                    api_type: 'readonly',
                     description: 'Computer Science'
                 },
                 course_number: {
                     value: '301R',
-                    api_type: UAPI.ApiType.READONLY
+                    api_type: 'readonly'
                 },
                 section_number: {
                     value: '003',
-                    api_type: UAPI.ApiType.READONLY,
+                    api_type: 'readonly',
                     key: true
                 },
                 term_code: {
                     value: 'S',
-                    api_type: UAPI.ApiType.READONLY,
+                    api_type: 'readonly',
                     description: 'Semester Long'
                 },
                 class_provider: {
                     value: 'DAY',
                     domain: 'https://api.byu.edu/byuapi/meta/registration/class_providers',
-                    api_type: UAPI.ApiType.READONLY
+                    api_type: 'readonly'
                 },
                 instruction_mode: {
                     value: null,
-                    api_type: UAPI.ApiType.READONLY,
+                    api_type: 'readonly',
                     description: null
                 },
                 percent_classroom_time: {
                     value: null,
-                    api_type: UAPI.ApiType.READONLY
+                    api_type: 'readonly'
                 },
                 course_title: {
                     value: 'Topics in Computer Science',
-                    api_type: UAPI.ApiType.RELATED,
+                    api_type: 'related',
                     related_resource: 'https://api.byu.edu/byuapi/courses/v1/Fall2018,C%20S,301R'
                 },
                 credit_hours: {
                     value: '3.0',
-                    api_type: UAPI.ApiType.READONLY
+                    api_type: 'readonly'
                 },
                 end_date: {
                     value: '2018-12-13',
-                    api_type: UAPI.ApiType.READONLY
+                    api_type: 'readonly'
                 },
                 final_exam_schedule: {
                     object: {
                         building: {
                             value: 'RB',
                             description: 'Richards Building',
-                            api_type: UAPI.ApiType.RELATED,
+                            api_type: 'related',
                             related_resource: 'https://api.byu.edu/byuapi/classes/v2/Fall2018,C%20S,301R,003/assigned_schedules/FINAL%20EXAM,1',
                             domain: 'https://api.byu.edu/byuapi/meta/classes/buildings'
                         },
                         room: {
                             value: '164',
-                            api_type: UAPI.ApiType.RELATED,
+                            api_type: 'related',
                             related_resource: 'https://api.byu.edu/byuapi/classes/v2/Fall2018,C%20S,301R,003/assigned_schedules/FINAL%20EXAM,1'
                         },
                         days: {
                             value: 'S',
-                            api_type: UAPI.ApiType.RELATED,
+                            api_type: 'related',
                             related_resource: 'https://api.byu.edu/byuapi/classes/v2/Fall2018,C%20S,301R,003/assigned_schedules/FINAL%20EXAM,1'
                         },
                         start_time: {
                             value: '11:00',
-                            api_type: UAPI.ApiType.RELATED,
+                            api_type: 'related',
                             description: '11:00am',
                             related_resource: 'https://api.byu.edu/byuapi/classes/v2/Fall2018,C%20S,301R,003/assigned_schedules/FINAL%20EXAM,1'
                         },
                         end_time: {
                             value: '14:00',
-                            api_type: UAPI.ApiType.RELATED,
+                            api_type: 'related',
                             description: '2:00pm',
                             related_resource: 'https://api.byu.edu/byuapi/classes/v2/Fall2018,C%20S,301R,003/assigned_schedules/FINAL%20EXAM,1'
                         },
                         start_date: {
                             value: '2018-12-15',
-                            api_type: UAPI.ApiType.RELATED,
+                            api_type: 'related',
                             related_resource: 'https://api.byu.edu/byuapi/classes/v2/Fall2018,C%20S,301R,003/assigned_schedules/FINAL%20EXAM,1'
                         },
                         end_date: {
                             value: '2018-12-15',
-                            api_type: UAPI.ApiType.RELATED,
+                            api_type: 'related',
                             related_resource: 'https://api.byu.edu/byuapi/classes/v2/Fall2018,C%20S,301R,003/assigned_schedules/FINAL%20EXAM,1'
                         }
                     },
-                    api_type: UAPI.ApiType.READONLY
+                    api_type: 'readonly'
                 },
                 help_section: {
                     value: false,
-                    api_type: UAPI.ApiType.READONLY
+                    api_type: 'readonly'
                 },
                 honors_section: {
                     value: false,
-                    api_type: UAPI.ApiType.READONLY
+                    api_type: 'readonly'
                 },
                 instructors: {
                     object_array: [
                         {
                             instructor_byu_id: {
                                 value: '333333333',
-                                api_type: UAPI.ApiType.RELATED,
+                                api_type: 'related',
                                 description: 'Bunny, Bugs',
                                 related_resource: 'https://api.byu.edu/byuapi/persons/v3/333333333'
                             },
                             instructor_type: {
                                 value: 'PRIMARY',
-                                api_type: UAPI.ApiType.READONLY,
+                                api_type: 'readonly',
                                 description: 'Primary Instructor'
                             }
                         },
                         {
                             instructor_byu_id: {
                                 value: '555555555',
-                                api_type: UAPI.ApiType.RELATED,
+                                api_type: 'related',
                                 description: 'Duck, Daffy',
                                 related_resource: 'https://api.byu.edu/byuapi/persons/v3/555555555'
                             },
                             instructor_type: {
                                 value: 'TEACHING ASSISTANT',
-                                api_type: UAPI.ApiType.READONLY,
+                                api_type: 'readonly',
                                 description: 'Teaching Assistant'
                             }
                         }
                     ],
-                    api_type: UAPI.ApiType.READONLY
+                    api_type: 'readonly'
                 },
                 lab_section: {
                     value: false,
-                    api_type: UAPI.ApiType.READONLY
+                    api_type: 'readonly'
                 },
                 lms_name: {
                     value: 'Learning Suite',
                     domain: 'https://api.byu.edu/byuapi/meta/registration/lms_names',
-                    api_type: UAPI.ApiType.READONLY
+                    api_type: 'readonly'
                 },
                 online_section: {
                     value: false,
-                    api_type: UAPI.ApiType.READONLY
+                    api_type: 'readonly'
                 },
                 position_in_queue: {
                     value: 1,
-                    api_type: UAPI.ApiType.SYSTEM
+                    api_type: 'system'
                 },
                 quiz_section: {
                     value: false,
-                    api_type: UAPI.ApiType.READONLY
+                    api_type: 'readonly'
                 },
                 reason_skipped: {
                     value: 'Adding ACC 402  will exceed the maximum of 18.0 credit hours allowed for this semester',
-                    api_type: UAPI.ApiType.SYSTEM
+                    api_type: 'system'
                 },
                 requested_by_byu_id: {
                     value: '123456789',
-                    api_type: UAPI.ApiType.SYSTEM,
+                    api_type: 'system',
                     description: 'LastName, FirstName'
                 },
                 requested_datetime: {
                     value: '2018-07-04T11:22:33.445Z',
-                    api_type: UAPI.ApiType.SYSTEM
+                    api_type: 'system'
                 },
                 start_date: {
                     value: '2018-09-04',
-                    api_type: UAPI.ApiType.READONLY
+                    api_type: 'readonly'
                 },
                 when_taught: {
                     object_array: [
@@ -285,40 +285,40 @@ export namespace StudentsV3API {
                             building: {
                                 value: 'RB',
                                 description: 'Richards Building',
-                                api_type: UAPI.ApiType.RELATED,
+                                api_type: 'related',
                                 related_resource: 'https://api.byu.edu/byuapi/classes/v2/Fall2018,C%20S,301R,003/assigned_schedules/CLS,3',
                                 domain: 'https://api.byu.edu/byuapi/meta/classes/buildings'
                             },
                             room: {
                                 value: '206',
-                                api_type: UAPI.ApiType.RELATED,
+                                api_type: 'related',
                                 related_resource: 'https://api.byu.edu/byuapi/classes/v2/Fall2018,C%20S,301R,003/assigned_schedules/CLS,3'
                             },
                             days: {
                                 value: 'MW',
-                                api_type: UAPI.ApiType.RELATED,
+                                api_type: 'related',
                                 related_resource: 'https://api.byu.edu/byuapi/classes/v2/Fall2018,C%20S,301R,003/assigned_schedules/CLS,3'
                             },
                             start_time: {
                                 value: '12:00',
-                                api_type: UAPI.ApiType.RELATED,
+                                api_type: 'related',
                                 description: '12:00pm',
                                 related_resource: 'https://api.byu.edu/byuapi/classes/v2/Fall2018,C%20S,301R,003/assigned_schedules/CLS,3'
                             },
                             end_time: {
                                 value: '12:50',
-                                api_type: UAPI.ApiType.RELATED,
+                                api_type: 'related',
                                 description: '12:50pm',
                                 related_resource: 'https://api.byu.edu/byuapi/classes/v2/Fall2018,C%20S,301R,003/assigned_schedules/CLS,3'
                             },
                             start_date: {
                                 value: '2018-09-04',
-                                api_type: UAPI.ApiType.RELATED,
+                                api_type: 'related',
                                 related_resource: 'https://api.byu.edu/byuapi/classes/v2/Fall2018,C%20S,301R,003/assigned_schedules/CLS,3'
                             },
                             end_date: {
                                 value: '2018-12-13',
-                                api_type: UAPI.ApiType.RELATED,
+                                api_type: 'related',
                                 related_resource: 'https://api.byu.edu/byuapi/classes/v2/Fall2018,C%20S,301R,003/assigned_schedules/CLS,3'
                             }
                         },
@@ -326,45 +326,45 @@ export namespace StudentsV3API {
                             building: {
                                 value: 'RB',
                                 description: 'Richards Building',
-                                api_type: UAPI.ApiType.RELATED,
+                                api_type: 'related',
                                 related_resource: 'https://api.byu.edu/byuapi/classes/v2/Fall2018,C%20S,301R,003/assigned_schedules/CLS,2',
                                 domain: 'https://api.byu.edu/byuapi/meta/classes/buildings'
                             },
                             room: {
                                 value: '164',
-                                api_type: UAPI.ApiType.RELATED,
+                                api_type: 'related',
                                 related_resource: 'https://api.byu.edu/byuapi/classes/v2/Fall2018,C%20S,301R,003/assigned_schedules/CLS,2'
                             },
                             days: {
                                 value: 'F',
-                                api_type: UAPI.ApiType.RELATED,
+                                api_type: 'related',
                                 related_resource: 'https://api.byu.edu/byuapi/classes/v2/Fall2018,C%20S,301R,003/assigned_schedules/CLS,2'
                             },
                             start_time: {
                                 value: '12:00',
-                                api_type: UAPI.ApiType.RELATED,
+                                api_type: 'related',
                                 description: '12:00pm',
                                 related_resource: 'https://api.byu.edu/byuapi/classes/v2/Fall2018,C%20S,301R,003/assigned_schedules/CLS,2'
                             },
                             end_time: {
                                 value: '12:50',
-                                api_type: UAPI.ApiType.RELATED,
+                                api_type: 'related',
                                 description: '12:50pm',
                                 related_resource: 'https://api.byu.edu/byuapi/classes/v2/Fall2018,C%20S,301R,003/assigned_schedules/CLS,2'
                             },
                             start_date: {
                                 value: '2018-09-04',
-                                api_type: UAPI.ApiType.RELATED,
+                                api_type: 'related',
                                 related_resource: 'https://api.byu.edu/byuapi/classes/v2/Fall2018,C%20S,301R,003/assigned_schedules/CLS,2'
                             },
                             end_date: {
                                 value: '2018-12-13',
-                                api_type: UAPI.ApiType.RELATED,
+                                api_type: 'related',
                                 related_resource: 'https://api.byu.edu/byuapi/classes/v2/Fall2018,C%20S,301R,003/assigned_schedules/CLS,2'
                             }
                         }
                     ],
-                    api_type: UAPI.ApiType.READONLY
+                    api_type: 'readonly'
                 }
             }
         ]


### PR DESCRIPTION
This PR removes the ApiType enum and adds the ApiType and ObjectApiType String Literal types.

Using an enum prevents users from specifying the api type field as a string literal. For example:

```typescript
const myProp: UAPI.Value.String = {
  value: 'cool-value',
  api_type: 'modifiable' // TS2322: Type '"modifiable"' is not assignable to type 'ApiType'.
}
```

Previously, this was accomplished by using the enum type as value
```typescript
const myProp: UAPI.Value.String = {
  value: 'cool-value',
  api_type: UAPI.ApiType.MODIFIABLE
}
```

Since the expected javascript isn't compiled and distributed with the type definitions, using the types in this way resulted in a javascript runtime error similar to `Unexpected token 'export'`.